### PR TITLE
fix bug that return empty “where object” if filter contains utf8letter

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,13 +102,13 @@ class SequelizeQueryStringParser {
   find (expression) {
     let where = {}
     if (expression.match(new RegExp(`(([\\w|.]+)\\s(\\w+)\\s([\\w|\\s|%|_|${utf8letters}]+),?)+`))) {
-      let parts = (expression).split(',')
+      let parts = (expression).split(/,\s/)
       const operators = this.operators()
       for (let i = 0; i < parts.length; i++) {
         // build a regexp to match filter expressions
         const lhs = '[\\w|.]+'
         const op = '\\w+'
-        const rhs = `[A-Za-z0-9.+@:/()%_\\s\\-\\xAA\\xB5\\xBA${utf8letters}]+`
+        const rhs = `.+`
         const expressionRegExp = new RegExp(`(${lhs})\\s+(${op})\\s+(${rhs})`)
         if (parts[i].match(expressionRegExp)) {
           let prop = RegExp.$1

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ class SequelizeQueryStringParser {
    */
   find (expression) {
     let where = {}
-    if (expression.match(/(([\w|.]+)\s(\w+)\s([\w|\s|%|_]+),?)+/)) {
+    if (expression.match(new RegExp(`(([\\w|.]+)\\s(\\w+)\\s([\\w|\\s|%|_|${utf8letters}]+),?)+`))) {
       let parts = (expression).split(',')
       const operators = this.operators()
       for (let i = 0; i < parts.length; i++) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "sequelize-querystring",
-  "version": "0.10.0",
+  "name": "sequelize-querystring-utf8",
+  "version": "0.10.1",
   "description": "Convert the request query string into sequelize compatible where and sort clauses.",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-querystring-utf8",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Convert the request query string into sequelize compatible where and sort clauses.",
   "main": "index.js",
   "engines": {

--- a/test/test_filter.js
+++ b/test/test_filter.js
@@ -9,6 +9,18 @@ const sqs = require('../index.js')
 
 
 describe('Convert query strings into Sequelize find queries.', (done) => {
+  it('(eq) Find convert equal operator with utf8letter to where.', () => {
+    let qs = 'geoId eq 测试'
+    let where = sqs.find(qs)
+    expect(where).to.be.instanceof(Object)
+    expect(where).to.have.deep.property('geoId.$eq', '测试')
+    // test symbolic
+    where = sqsSym.find(qs)
+    expect(where).to.be.instanceof(Object)
+    expect(where).to.have.property('geoId')
+    expect(where.geoId).to.have.property(sequelize.Op.eq, '测试')
+  })
+
   // test string, integer and UUID
   it('(eq) Find convert equal operator to where.', () => {
     let qs = 'geoId eq 4301'


### PR DESCRIPTION
In `find` method, `if (expression.match(/(([\w|.]+)\s(\w+)\s([\w|\s|%|_]+),?)+/))`,
if expression contains utf8letters the `if` condition would be false and return empty where object.